### PR TITLE
Add support for configurable number of children

### DIFF
--- a/node.go
+++ b/node.go
@@ -5,8 +5,7 @@ import (
 )
 
 type Node struct {
-	Left  []byte ",omitempty"
-	Right []byte ",omitempty"
+	Children [][]byte ",omitempty"
 
 	Content []byte ",omitempty"
 }

--- a/node_test.go
+++ b/node_test.go
@@ -8,8 +8,7 @@ import (
 
 func TestExportImport(t *testing.T) {
 	node := &Node{
-		Left:  []byte("left"),
-		Right: []byte("right"),
+		Children: [][]byte{[]byte("left"), []byte("right")},
 	}
 
 	nodeData := node.Bytes()

--- a/tree_test.go
+++ b/tree_test.go
@@ -18,8 +18,9 @@ func TestCreateLeaves(t *testing.T) {
 	assert.Equal(t, arbData, recoveredData)
 }
 
-func TestBuildLevel(t *testing.T) {
+func TestCreateRecoverLevel(t *testing.T) {
 	chunkSize := 1024
+	children := 2
 	arbData := []byte(RandomString(chunkSize*10 + 2))
 	memStorage := NewMemStorage()
 	ctx := context.Background()
@@ -28,20 +29,24 @@ func TestBuildLevel(t *testing.T) {
 	levelHashes, err := storeNodes(ctx, nodes, memStorage)
 	assert.NoError(t, err)
 
-	levelNodes, err := buildLevel(levelHashes)
+	levelNodes, err := buildLevel(levelHashes, uint64(children))
 	assert.NoError(t, err)
-	assert.Equal(t, 6, len(levelNodes))
+
+	recoveredLeaves, err := recoverLevel(ctx, levelNodes, memStorage)
+	assert.NoError(t, err)
+	assert.Equal(t, arbData, recoverData(recoveredLeaves))
 }
 
 func TestCreateRecoverTree(t *testing.T) {
 	chunkSize := 1024
+	children := 2
 	arbData := []byte(RandomString(chunkSize*10 + 2))
 	memStorage := NewMemStorage()
 	ctx := context.Background()
 
-	root, err := NewTree(ctx, arbData, uint64(chunkSize), memStorage)
+	root, err := NewTree(ctx, arbData, uint64(chunkSize), uint64(children), memStorage)
 	assert.NoError(t, err)
-	assert.Equal(t, "5nzGdJMc7vU17k7Mkgw2RTZHveKs2RVVzVTuMzfeq5i6", base58.Encode(root))
+	assert.Equal(t, "B5CuNQ58N5tXT7sqBmbabiJa4HgR9aiwCcvCm9kpDRvc", base58.Encode(root))
 
 	recoveredData, err := RecoverTree(ctx, root, memStorage)
 	assert.NoError(t, err)


### PR DESCRIPTION
Configure how many children each node can have. In some cases, a flatter tree can lead to the retrieval of far fewer nodes from the network.